### PR TITLE
ts test tweaks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+HOST=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 node_modules/
 src/declarations/
 package-lock.json
+.env

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 > : descended.
 
+## Tests
+
+```sh
+cp .env.example .env
+npm i
+npm run makeadmin
+npm run test:dfx
+```
+
 ## Project Structure
 
 ```text

--- a/lib/actor.ts
+++ b/lib/actor.ts
@@ -1,10 +1,11 @@
+import 'dotenv/config'
 import { Actor, ActorSubclass, HttpAgent, HttpAgentOptions } from "@dfinity/agent";
 import { IDL } from "@dfinity/candid";
 import { Principal } from "@dfinity/principal";
 
 export function createActor<T>(canisterId: string | Principal, idlFactory: IDL.InterfaceFactory, options: HttpAgentOptions) : ActorSubclass<T> {
     const agent = new HttpAgent({
-        host: "http://localhost:8000",
+        host: process.env.HOST,
         ...options
     });
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "makeadmin": "npx ts-node -e 'require(\"./lib/keys.ts\").generateKey(\"admin\")'",
     "deploy": "npx ts-node scripts/deploy.ts",
     "test": "mocha --timeout 10000 -r ts-node/register 'tests/**/*.ts'",
     "test:dfx": "dfx start --background --clean && ./.scripts/dfx-deploy && npm test && dfx stop"
@@ -9,6 +10,7 @@
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.23",
     "chai": "^4.3.6",
+    "dotenv": "^16.0.0",
     "mocha": "^9.2.2",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "target": "es2020",
     "module": "commonjs",
     "lib": [
-      "DOM"
+      "DOM",
+      "es5"
     ],
     "outDir": "./dist",
     "resolveJsonModule": true,


### PR DESCRIPTION
- adds a .env for config (I had to repoint my local agent to `127.0.0.1` because `localhost` wasn't connecting...)
- adds es5 lib to tsconf because something wasn't compiling
- adds npm script to generate admin key and simple test example to readme